### PR TITLE
Fix test determinism in latest release

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -78,6 +78,18 @@ jobs:
           command: test
           args: --workspace --exclude quillc --release --no-fail-fast
 
+      # This step, which is not timed, ensures that the zig compiler
+      # has built all necessary libc artifacts.
+      # This guarantees that future linking steps are deterministically fast,
+      # regardless of test execution order.
+      # Even if this fails, we should continue running the remainder of the tests.
+      - name: Build stdlib
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: run
+          args: --bin quill -- -svp stdlib/core build
+        continue-on-error: true
+
       - name: Run quillc test suite
         uses: actions-rs/cargo@v1.0.3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,9 @@ jobs:
           command: clippy
           args: -- -Dwarnings
 
+      # Since we're on linux, zig does not need to build libc artifacts.
+      # So there is no need to build some other project beforehand to get zig
+      # to produce these files in advance.
       - name: Run test suite
         uses: actions-rs/cargo@v1.0.3
         with:


### PR DESCRIPTION
This makes sure that the zig compiler generates libc artifacts before running timed tests.
Signed-off-by: thirdsgames <thirdsgames2018@gmail.com>