### PR TITLE
Fix running out of disk space

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: run
-          args: --bin quill -- -svp stdlib/core build
+          args: --bin quill --release -- -svp stdlib/core build
         continue-on-error: true
 
       - name: Run quillc test suite


### PR DESCRIPTION
Use release build to compile quill stdlib on release to fix running out of disk space while linking.